### PR TITLE
doc: Fix an unreadable register name hiding behind the border (chap 2.10.2)

### DIFF
--- a/doc/core/Progdokum.lyx
+++ b/doc/core/Progdokum.lyx
@@ -5455,8 +5455,12 @@ The error frames are distinguished from regular CAN frames by FRAME_FORMAT_W[ERF
 \end_layout
 
 \begin_layout Itemize
-Only FRAME_FORMAT_W[ERF], FRAME_FORMAT_W[IVLD], FRAME_FORMAT_W[RWCNT], FRAME_FOR
-MAT_W[ERF_POS] and FRAME_FORMAT_W[ERF_TYPE] are valid in FRAME_FORMAT_W.
+Only FRAME_FORMAT_W[ERF], FRAME_FORMAT_W[IVLD], FRAME_FORMAT_W[RWCNT],
+\begin_inset Newline newline
+\end_inset
+
+ FRAME_FORMAT_W[ERF_POS] and FRAME_FORMAT_W[ERF_TYPE] are valid in FRAME_FORMAT_
+W.
  Other fields of FRAME_FORMAT_W are reserved, and shall be ignored by SW
  reading the Error frame from RX buffer.
 \end_layout


### PR DESCRIPTION
In chapter 2.10.2 there was a bullet list with many register names in uppercase letters on one line. The line rendered to pdf hides some important part of a name of a register out of the page.
The proposed fix is a forced newline. This looks ugly, but is at least readable.
I'll attach screenshots of the relevant part before:
![before](https://github.com/user-attachments/assets/dbed5388-f934-4aeb-be49-563e81f2ff27)

and after the fix:
![after](https://github.com/user-attachments/assets/a621aa14-c93c-4e90-99cf-1dca3da473b9)
